### PR TITLE
Reapply black

### DIFF
--- a/src/rounders/decimal_overloads.py
+++ b/src/rounders/decimal_overloads.py
@@ -28,6 +28,8 @@ def _(x: decimal.Decimal, exponent: int) -> IntermediateForm:
         raise ValueError("Input must be finite")
 
     sign, digit_tuple, x_exponent = x.as_tuple()
+    # since x is finite, x_exponent can't be one of the special strings 'n', 'N', 'F'
+    assert isinstance(x_exponent, int)
     rounded = IntermediateForm.from_signed_fraction(
         sign=bool(sign),
         numerator=int("".join(map(str, digit_tuple))),

--- a/src/rounders/format.py
+++ b/src/rounders/format.py
@@ -113,7 +113,6 @@ class FormatSpecification:
     exponent_for_zero: int = 0
 
     def format(self, rounded: IntermediateForm) -> str:
-
         # Step 2: convert to string. Only supporting f-presentation format right now.
 
         # Get digits as a decimal string.
@@ -247,7 +246,6 @@ def format(value: Any, pattern: str) -> str:
     prerounded = preround(value, exponent - 1)
     rounded = format_specification.rounding_mode.round(prerounded)
     if format_specification.figures is not None:
-
         # Adjust if necessary.
         if len(str(rounded.significand)) == format_specification.figures + 1:
             rounded = rounded.to_zero()


### PR DESCRIPTION
This PR fixes some errors arising with newer versions of our checkers:

- Re-applies black to the codebase, for compatibility with the 2023 black stable style
- Adds a type narrowing assertion to help mypy out

