### PR TITLE
Rework rounding machinery

### DIFF
--- a/src/rounders/decimal_overloads.py
+++ b/src/rounders/decimal_overloads.py
@@ -31,7 +31,7 @@ def _(x: decimal.Decimal, exponent: int) -> IntermediateForm:
     # since x is finite, x_exponent can't be one of the special strings 'n', 'N', 'F'
     assert isinstance(x_exponent, int)
     rounded = IntermediateForm.from_signed_fraction(
-        sign=bool(sign),
+        sign=sign,
         numerator=int("".join(map(str, digit_tuple))),
         denominator=1,
         exponent=exponent - x_exponent,

--- a/src/rounders/decimal_overloads.py
+++ b/src/rounders/decimal_overloads.py
@@ -1,4 +1,3 @@
-import dataclasses
 import decimal
 
 from rounders.generics import decade, is_finite, is_zero, preround, to_type_of

--- a/src/rounders/decimal_overloads.py
+++ b/src/rounders/decimal_overloads.py
@@ -27,16 +27,17 @@ def _(x: decimal.Decimal, exponent: int) -> IntermediateForm:
     if not x.is_finite():
         raise ValueError("Input must be finite")
 
+    # We can convert directly to something of type IntermediateForm without changing
+    # the value, so we do that, ignoring the incoming 'exponent'.
     sign, digit_tuple, x_exponent = x.as_tuple()
     # since x is finite, x_exponent can't be one of the special strings 'n', 'N', 'F'
     assert isinstance(x_exponent, int)
-    rounded = IntermediateForm.from_signed_fraction(
+    significand = int("".join(map(str, digit_tuple)))
+    return IntermediateForm(
         sign=sign,
-        numerator=int("".join(map(str, digit_tuple))),
-        denominator=1,
-        exponent=exponent - x_exponent,
+        significand=significand,
+        exponent=x_exponent,
     )
-    return dataclasses.replace(rounded, exponent=exponent)
 
 
 @decade.register

--- a/src/rounders/float_overloads.py
+++ b/src/rounders/float_overloads.py
@@ -725,7 +725,7 @@ def _(x: float, exponent: int) -> IntermediateForm:
     if not math.isfinite(x):
         raise ValueError("Input must be finite")
 
-    sign = math.copysign(1.0, x) < 0.0
+    sign = int(math.copysign(1.0, x) < 0.0)
     numerator, denominator = abs(x).as_integer_ratio()
     return IntermediateForm.from_signed_fraction(
         sign=sign,

--- a/src/rounders/format.py
+++ b/src/rounders/format.py
@@ -244,11 +244,10 @@ def format(value: Any, pattern: str) -> str:
         exponent = max(bounds)
 
     prerounded = preround(value, exponent - 1)
-    rounded = format_specification.rounding_mode.round(prerounded)
+    rounded = prerounded.round(exponent, format_specification.rounding_mode)
     if format_specification.figures is not None:
         # Adjust if necessary.
-        if len(str(rounded.significand)) == format_specification.figures + 1:
-            rounded = rounded.to_zero()
+        rounded = rounded.nudge(format_specification.figures)
 
     # Step 2: convert to string. Only supporting e and f-presentation formats right now.
     return format_specification.format(rounded)

--- a/src/rounders/fraction_overloads.py
+++ b/src/rounders/fraction_overloads.py
@@ -43,7 +43,7 @@ def _(x: fractions.Fraction) -> bool:
 @preround.register
 def _(x: fractions.Fraction, exponent: int) -> IntermediateForm:
     return IntermediateForm.from_signed_fraction(
-        sign=x < 0,
+        sign=int(x < 0),
         numerator=abs(x.numerator),
         denominator=x.denominator,
         exponent=exponent,

--- a/src/rounders/generics.py
+++ b/src/rounders/generics.py
@@ -48,7 +48,13 @@ def preround(x: Any, exponent: int) -> IntermediateForm:
     """
     Pre-rounding step for value x.
 
-    Rounds x to the nearest integer multiple of 10**exponent, using the
-    round-for-reround rounding mode.
+    Converts the value x to a decimal value y of type IntermediateForm in such a way
+    that rounding y to any exponent greater than or equal to `exponent` is equivalent
+    to rounding x to that exponent, under any of the standard rounding modes.
+
+    For example, given a value of 22/7=3.142857142857... and an exponent of -3, an
+    IntermediateForm element representing the value 3.1428 might be returned. When
+    rounded to 3 or fewer decimal places, 3.1428 rounds the same way as 22/7 under
+    any of the rounding modes provided by this package.
     """
     raise NotImplementedError(f"No overload available for type {type(x)}")

--- a/src/rounders/generics.py
+++ b/src/rounders/generics.py
@@ -52,6 +52,9 @@ def preround(x: Any, exponent: int) -> IntermediateForm:
     that rounding y to any exponent greater than or equal to `exponent` is equivalent
     to rounding x to that exponent, under any of the standard rounding modes.
 
+    For values that can be represented exactly in the target IntermediateForm type,
+    an exact conversion can be performed, and then `exponent` can be ignored.
+
     For example, given a value of 22/7=3.142857142857... and an exponent of -3, an
     IntermediateForm element representing the value 3.1428 might be returned. When
     rounded to 3 or fewer decimal places, 3.1428 rounds the same way as 22/7 under

--- a/src/rounders/int_overloads.py
+++ b/src/rounders/int_overloads.py
@@ -36,9 +36,8 @@ def _(x: int) -> bool:
 
 @preround.register
 def _(x: int, exponent: int) -> IntermediateForm:
-    return IntermediateForm.from_signed_fraction(
+    return IntermediateForm(
         sign=int(x < 0),
-        numerator=abs(x),
-        denominator=1,
-        exponent=exponent,
+        significand=abs(x),
+        exponent=0,
     )

--- a/src/rounders/int_overloads.py
+++ b/src/rounders/int_overloads.py
@@ -37,7 +37,7 @@ def _(x: int) -> bool:
 @preround.register
 def _(x: int, exponent: int) -> IntermediateForm:
     return IntermediateForm.from_signed_fraction(
-        sign=x < 0,
+        sign=int(x < 0),
         numerator=abs(x),
         denominator=1,
         exponent=exponent,

--- a/src/rounders/test/test_format.py
+++ b/src/rounders/test/test_format.py
@@ -219,13 +219,13 @@ class TestFormatFromSpecification(unittest.TestCase):
         )
         self.assertEqual(
             format_specification.format(
-                IntermediateForm(sign=False, significand=23, exponent=-2)
+                IntermediateForm(sign=0, significand=23, exponent=-2)
             ),
             ".23",
         )
         self.assertEqual(
             format_specification.format(
-                IntermediateForm(sign=False, significand=67, exponent=-3)
+                IntermediateForm(sign=0, significand=67, exponent=-3)
             ),
             ".067",
         )


### PR DESCRIPTION
A minor rework aimed at supporting formatting needs.

Key changes:

- Most of the rounding logic has been moved to the `IntermediateForm` class. The individual rounding modes now only "know" about how to round a value with one digit following the decimal point to an integer.
- `IntermediateForm.sign` is now an `int` rather than a `bool`
- The "preround" step is no longer constrained to round to _exactly_ the right number of digits + 1; it can return any value that rounds correctly (under a minimum constraint on the exponent). For `int` and `Decimal`, `preround` simply converts the value to `IntermediateForm` and does no rounding.