### PR TITLE
Fix preround for Fraction and float types

### DIFF
--- a/src/rounders/float_overloads.py
+++ b/src/rounders/float_overloads.py
@@ -731,5 +731,5 @@ def _(x: float, exponent: int) -> IntermediateForm:
         sign=sign,
         numerator=numerator,
         denominator=denominator,
-        exponent=exponent,
+        exponent=exponent - 1,
     )

--- a/src/rounders/format.py
+++ b/src/rounders/format.py
@@ -243,7 +243,7 @@ def format(value: Any, pattern: str) -> str:
 
         exponent = max(bounds)
 
-    prerounded = preround(value, exponent - 1)
+    prerounded = preround(value, exponent)
     rounded = prerounded.round(exponent, format_specification.rounding_mode)
     if format_specification.figures is not None:
         # Adjust if necessary.

--- a/src/rounders/fraction_overloads.py
+++ b/src/rounders/fraction_overloads.py
@@ -46,5 +46,5 @@ def _(x: fractions.Fraction, exponent: int) -> IntermediateForm:
         sign=int(x < 0),
         numerator=abs(x.numerator),
         denominator=x.denominator,
-        exponent=exponent,
+        exponent=exponent - 1,
     )

--- a/src/rounders/round_to.py
+++ b/src/rounders/round_to.py
@@ -31,7 +31,7 @@ def round_to_int(x: Any, *, mode: RoundingMode = TIES_TO_EVEN) -> int:
     if not is_finite(x):
         raise ValueError("x must be finite")
 
-    rounded = preround(x, -1).round(0, mode)
+    rounded = preround(x, 0).round(0, mode)
     return -rounded.significand if rounded.sign else rounded.significand
 
 
@@ -55,7 +55,7 @@ def round_to_places(
     if not is_finite(value):
         return value
 
-    prerounded = preround(value, -places - 1)
+    prerounded = preround(value, -places)
     rounded = prerounded.round(-places, mode)
     return to_type_of(value, rounded)
 
@@ -88,9 +88,9 @@ def round_to_figures(x: Any, figures: int, *, mode: RoundingMode = TIES_TO_EVEN)
     #  1.23e+02
     #  0.00e+00
 
-    exponent = (0 if is_zero(x) else decade(x)) - figures
+    exponent = (0 if is_zero(x) else decade(x)) + 1 - figures
     prerounded = preround(x, exponent)
-    rounded = prerounded.round(exponent + 1, mode)
+    rounded = prerounded.round(exponent, mode)
 
     # Adjust if the result has one more significant figure than expected.
     # This can happen when a value at the uppermost end of a decade gets


### PR DESCRIPTION
Since #25, the definition of `preround` didn't match the description, for `float` and `Fraction`: we want the incoming exponent to be the target exponent. The preround machinery is free to return anything with exponent equal to or lower than the given exponent.

This was still working because we were still (incorrectly) decrementing the exponent passed to `preround` in the first place, passing one less than the target exponent instead of the target exponent itself.

This PR fixes both issues.

Not a user-facing bug, since the functions exposed in the API continued to work as expected.