### PR TITLE
Support exact formatting

### DIFF
--- a/src/rounders/decimal_overloads.py
+++ b/src/rounders/decimal_overloads.py
@@ -1,4 +1,5 @@
 import decimal
+from typing import Optional
 
 from rounders.generics import decade, is_finite, is_zero, preround, to_type_of
 from rounders.intermediate import IntermediateForm
@@ -22,7 +23,7 @@ def _(x: decimal.Decimal) -> bool:
 
 
 @preround.register
-def _(x: decimal.Decimal, exponent: int) -> IntermediateForm:
+def _(x: decimal.Decimal, exponent: Optional[int]) -> IntermediateForm:
     if not x.is_finite():
         raise ValueError("Input must be finite")
 

--- a/src/rounders/float_overloads.py
+++ b/src/rounders/float_overloads.py
@@ -1,7 +1,7 @@
 import fractions
 import math
 import struct
-from typing import cast
+from typing import Optional, cast
 
 from rounders.generics import decade, is_finite, is_zero, preround, to_type_of
 from rounders.intermediate import IntermediateForm
@@ -721,7 +721,7 @@ def _(x: float) -> bool:
 
 
 @preround.register
-def _(x: float, exponent: int) -> IntermediateForm:
+def _(x: float, exponent: Optional[int]) -> IntermediateForm:
     if not math.isfinite(x):
         raise ValueError("Input must be finite")
 
@@ -731,5 +731,5 @@ def _(x: float, exponent: int) -> IntermediateForm:
         sign=sign,
         numerator=numerator,
         denominator=denominator,
-        exponent=exponent - 1,
+        exponent=exponent - 1 if exponent is not None else None,
     )

--- a/src/rounders/fraction_overloads.py
+++ b/src/rounders/fraction_overloads.py
@@ -1,5 +1,5 @@
 import fractions
-from typing import cast
+from typing import Optional, cast
 
 from rounders.generics import decade, is_finite, is_zero, preround, to_type_of
 from rounders.intermediate import IntermediateForm
@@ -41,10 +41,10 @@ def _(x: fractions.Fraction) -> bool:
 
 
 @preround.register
-def _(x: fractions.Fraction, exponent: int) -> IntermediateForm:
+def _(x: fractions.Fraction, exponent: Optional[int]) -> IntermediateForm:
     return IntermediateForm.from_signed_fraction(
         sign=int(x < 0),
         numerator=abs(x.numerator),
         denominator=x.denominator,
-        exponent=exponent - 1,
+        exponent=exponent - 1 if exponent is not None else None,
     )

--- a/src/rounders/generics.py
+++ b/src/rounders/generics.py
@@ -3,7 +3,7 @@ Generic extensible computation functions that use singledispatch.
 """
 
 import functools
-from typing import Any
+from typing import Any, Optional
 
 from rounders.intermediate import IntermediateForm
 
@@ -44,7 +44,7 @@ def is_zero(x: Any) -> bool:
 
 
 @functools.singledispatch
-def preround(x: Any, exponent: int) -> IntermediateForm:
+def preround(x: Any, exponent: Optional[int]) -> IntermediateForm:
     """
     Pre-rounding step for value x.
 
@@ -54,6 +54,9 @@ def preround(x: Any, exponent: int) -> IntermediateForm:
 
     For values that can be represented exactly in the target IntermediateForm type,
     an exact conversion can be performed, and then `exponent` can be ignored.
+
+    If exponent is None, then this should either perform an exact conversion, or
+    raise ValueError if such an exact conversion isn't possible.
 
     For example, given a value of 22/7=3.142857142857... and an exponent of -3, an
     IntermediateForm element representing the value 3.1428 might be returned. When

--- a/src/rounders/int_overloads.py
+++ b/src/rounders/int_overloads.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from rounders.generics import decade, is_finite, is_zero, preround, to_type_of
 from rounders.intermediate import IntermediateForm
@@ -35,7 +35,7 @@ def _(x: int) -> bool:
 
 
 @preround.register
-def _(x: int, exponent: int) -> IntermediateForm:
+def _(x: int, exponent: Optional[int]) -> IntermediateForm:
     return IntermediateForm(
         sign=int(x < 0),
         significand=abs(x),

--- a/src/rounders/intermediate.py
+++ b/src/rounders/intermediate.py
@@ -11,7 +11,7 @@ from rounders.modes import RoundingMode
 
 def _smallest_ten_power_multiple(d: int) -> int:
     """
-    Find smallest power of 10 that's divisible by d.
+    Find smallest power of 10 that's divisible by a positive integer d.
 
     Raises ValueError if there's no such power.
     """
@@ -76,10 +76,15 @@ class IntermediateForm:
         """
         Create from a quotient of the form ±(n/d) with the target exponent, using
         round-for-reround.
+
+        If exponent is None, then the signed fraction must be exactly representable
+        in decimal format, otherwise a ValueError will be raised.
+
+        `numerator` and `denominator` must be relatively prime, `denominator` must be
+        positive, and `numerator` must be nonnegative.
         """
-        assert (
-            0 <= numerator and 0 < denominator and math.gcd(numerator, denominator) == 1
-        )
+        if numerator < 0 or denominator <= 0 or math.gcd(numerator, denominator) != 1:
+            raise ValueError("Invalid signed fraction representation")
 
         # Case where exponent is None: convert exactly if possible, else raise
         # a ValueError. We use the largest nonpositive exponent possible.

--- a/src/rounders/intermediate.py
+++ b/src/rounders/intermediate.py
@@ -2,10 +2,33 @@
 Representations of intermediate values.
 """
 
+import math
 from dataclasses import dataclass, replace
-from typing import cast
+from typing import Optional, cast
 
 from rounders.modes import RoundingMode
+
+
+def _smallest_ten_power_multiple(d: int) -> int:
+    """
+    Find smallest power of 10 that's divisible by d.
+
+    Raises ValueError if there's no such power.
+    """
+    assert d > 0
+
+    two_exp = (d & -d).bit_length() - 1
+    d >>= two_exp
+
+    five_exp = 0
+    while d % 5 == 0:
+        d //= 5
+        five_exp += 1
+
+    if d != 1:
+        raise ValueError("d is not a divisor of any power of 10")
+
+    return max(two_exp, five_exp)
 
 
 @dataclass(frozen=True)
@@ -42,18 +65,33 @@ class IntermediateForm:
             raise ValueError("Invalid representation of an IntermediateForm")
         return cls(
             sign=sign,
-            significand=int(''.join(map(str, digits))),
+            significand=int("".join(map(str, digits))),
             exponent=exponent,
         )
 
     @classmethod
     def from_signed_fraction(
-        cls, *, sign: int, numerator: int, denominator: int, exponent: int
+        cls, *, sign: int, numerator: int, denominator: int, exponent: Optional[int]
     ) -> "IntermediateForm":
         """
         Create from a quotient of the form ±(n/d) with the target exponent, using
         round-for-reround.
         """
+        assert (
+            0 <= numerator and 0 < denominator and math.gcd(numerator, denominator) == 1
+        )
+
+        # Case where exponent is None: convert exactly if possible, else raise
+        # a ValueError. We use the largest nonpositive exponent possible.
+        if exponent is None:
+            e = _smallest_ten_power_multiple(denominator)
+            assert 10**e % denominator == 0
+            return IntermediateForm(
+                sign=sign,
+                significand=numerator * (10**e // denominator),
+                exponent=-e,
+            )
+
         if exponent <= 0:
             n, d = numerator * cast(int, 10**-exponent), denominator
         else:
@@ -67,12 +105,33 @@ class IntermediateForm:
             exponent=exponent,
         )
 
+    @property
+    def figures(self) -> int:
+        """
+        Number of decimal digits in the significand, or zero if the significand is zero.
+        """
+        return len(str(self.significand)) if self.significand != 0 else 0
+
+    @property
+    def decade(self) -> Optional[int]:
+        """
+        Returns an integer e such that 10**e <= abs(self) < 10**(e+1).
+
+        If the value represented is zero, returns None.
+        """
+        if self.significand == 0:
+            return None
+        return self.exponent + self.figures - 1
+
     def nudge(self, figures: int) -> "IntermediateForm":
         """
         Drop a zero in cases where rounding led us to end up with an extra zero.
         """
-        if len(str(self.significand)) != figures + 1:
+        if self.figures <= figures:
             return self
+
+        if self.figures != figures + 1:
+            raise ValueError("Can't drop more than one zero")
 
         new_significand, tenths = divmod(self.significand, 10)
         if tenths:
@@ -110,5 +169,5 @@ class IntermediateForm:
                 exponent=exponent,
             )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{'-' * self.sign}{self.significand}e{self.exponent}"

--- a/src/rounders/test/test_round_for_format.py
+++ b/src/rounders/test/test_round_for_format.py
@@ -3,17 +3,17 @@ Tests for round_for_format.
 """
 
 import dataclasses
+import fractions
+import math
 import unittest
+from typing import Any, Optional
 
-from rounders.intermediate import IntermediateForm
-from rounders.generics import decade, preround
-from rounders.modes import TIES_TO_EVEN, TO_AWAY, TO_ZERO
+from rounders.generics import decade, is_zero, preround
+from rounders.intermediate import IntermediateForm, _smallest_ten_power_multiple
+from rounders.modes import TIES_TO_EVEN, TO_AWAY, TO_ZERO, RoundingMode
 
-# XXX Test cases where rounding changes the exponent.
-# XXX Tests for round to figures when rounding zero.
 # XXX Consider implementing __contains__ (possibly as a synonym for is_representable)
 # XXX Don't use Decimal in from_str
-# XXX Tests for the case where neither maximum_figures not minimum_exponent is supplied.
 # XXX Add support for suppressing sign of zero.
 # XXX Fix typing issues.
 # XXX Later on, we should allow decade to be a lower bound. If it's
@@ -31,9 +31,12 @@ from rounders.modes import TIES_TO_EVEN, TO_AWAY, TO_ZERO
 #     Or possibly a method on IntermediateForm. Or both.
 # XXX Test case where prerounding rounds a nonzero value to zero, so that the
 #     original value has a valid decade but the prerounded value does not.
-
-
-from typing import Optional
+# XXX Consider making unsigned zero the default.
+# XXX Think about exponent preservation (e.g., for Decimal inputs); what should
+#     rounding do?
+# XXX Consider format flag requiring particular exponent for zero.
+# XXX Remove tests for _smallest_ten_power_multiple
+# XXX Make _smallest_ten_power_multiple more efficient
 
 
 @dataclasses.dataclass(frozen=True)
@@ -51,32 +54,57 @@ class TargetFormat:
     # Maximum number of significant figures in the result.
     maximum_figures: Optional[int] = None
 
+    def target_exponent(self, decade: Optional[int]) -> Optional[int]:
+        """
+        Exponent to round to, given the decade of the value being rounded.
+
+        The decade of a nonzero (finite) value v is the unique integer e
+        satisfying 10**e <= abs(v) < 10**(e+1). For a zero value, this function
+        accepts a decade of `None`.
+
+        A return value of None should be interpreted as -infinity - that is,
+        no rounding is permitted, and the value must be unchanged.
+        """
+        exponents = []
+        if self.minimum_exponent is not None:
+            exponents.append(self.minimum_exponent)
+        if self.maximum_figures is not None:
+            if decade is None:
+                # XXX Better heuristic for this; make this configurable.
+                decade = 0
+            exponents.append(decade + 1 - self.maximum_figures)
+        return max(exponents, default=None)
 
 
-def round_to_format(x, *, format: TargetFormat, mode=TIES_TO_EVEN):
-    if format.maximum_figures is format.minimum_exponent is None:
-        raise NotImplementedError()
+def round_for_format(
+    x: Any, *, format: TargetFormat, mode: RoundingMode = TIES_TO_EVEN
+) -> IntermediateForm:
+    # Preround if necessary.
+    # Shouldn't matter if decade(x) is an underestimate - we just end up computing more
+    # digits than necessary. In effect, we're saying that we know that x >= 10**d.
 
-    min_exps = []
+    # We _do_ assume that target_exponent is increasing with increasing decade.
+    decade_x = None if is_zero(x) else decade(x)
+    target_exponent = format.target_exponent(decade_x)
+    prerounded = preround(x, target_exponent)
+
+    actual_target_exponent = format.target_exponent(prerounded.decade)
+    assert (
+        target_exponent is None
+        or actual_target_exponent is not None
+        and actual_target_exponent >= target_exponent
+    )
+
+    if actual_target_exponent is None:
+        return prerounded
+
+    result = prerounded.round(actual_target_exponent, mode)
+
+    # Adjust in the case that rounding has changed the decade.
     if format.maximum_figures is not None:
-        # decade is allowed to be an underestimate here
-        decade_x = decade(x)
-        min_exps.append(decade_x + 1 - format.maximum_figures)
-    if format.minimum_exponent is not None:
-        min_exps.append(format.minimum_exponent)
-    prerounded = preround(x, max(min_exps))
+        result = result.nudge(format.maximum_figures)
 
-    # Note that prerounding _never_ changes the decade. We can therefore
-    # get the _true_ decade from prerounded.
-    min_exps = []
-    if format.maximum_figures is not None:
-        actual_decade = prerounded.exponent + len(str(prerounded.significand)) - 1
-        min_exps.append(actual_decade + 1 - format.maximum_figures)
-    if format.minimum_exponent is not None:
-        min_exps.append(format.minimum_exponent)
-    return prerounded.round(max(min_exps), mode)
-
-
+    return result
 
 
 class TestRoundForFormat(unittest.TestCase):
@@ -87,15 +115,22 @@ class TestRoundForFormat(unittest.TestCase):
         test_values = [
             (3.14159, TIES_TO_EVEN, "3.142"),
             (3.14159, TO_ZERO, "3.141"),
+            (9.9999, TIES_TO_EVEN, "10.000"),
+            (0.0, TIES_TO_EVEN, "0.000"),
+            (-0.0, TIES_TO_EVEN, "-0.000"),
+            (0.0, TO_ZERO, "0.000"),
+            (-0.0, TO_ZERO, "-0.000"),
+            (0.0, TO_AWAY, "0.000"),
+            (-0.0, TO_AWAY, "-0.000"),
         ]
 
         for unrounded, mode, expected in test_values:
             with self.subTest(unrounded=unrounded, mode=mode):
-                rounded = round_to_format(unrounded, format=format, mode=mode)
+                rounded = round_for_format(unrounded, format=format, mode=mode)
                 self.assertEqual(rounded, IntermediateForm.from_str(expected))
 
     def test_maximum_figures(self) -> None:
-        format = TargetFormat(maximum_figures = 3)
+        format = TargetFormat(maximum_figures=3)
 
         # Pairs (value, mode, expected)
         test_values = [
@@ -105,18 +140,29 @@ class TestRoundForFormat(unittest.TestCase):
             (12345.6, TIES_TO_EVEN, "123e2"),
             (0.00098765, TIES_TO_EVEN, "988e-6"),
             (0.00098765, TO_ZERO, "987e-6"),
+            # Check that exponent gets bumped down where necessary
+            (9.99612, TIES_TO_EVEN, "10.0"),
+            # Small integers
+            (1.0, TIES_TO_EVEN, "1.00"),
+            (2.0, TIES_TO_EVEN, "2.00"),
+            (3.0, TIES_TO_EVEN, "3.00"),
+            (-1.0, TIES_TO_EVEN, "-1.00"),
+            (-2.0, TIES_TO_EVEN, "-2.00"),
+            # Zeros; default behaviour is to use the same exponent that other small
+            # integers would use.
+            (0.0, TIES_TO_EVEN, "0.00"),
+            (-0.0, TIES_TO_EVEN, "-0.00"),
+            # Some tiny values
+            (1e-300, TIES_TO_EVEN, "1.00e-300"),
         ]
 
         for unrounded, mode, expected in test_values:
             with self.subTest(unrounded=unrounded, mode=mode):
-                rounded = round_to_format(unrounded, format=format, mode=mode)
+                rounded = round_for_format(unrounded, format=format, mode=mode)
                 self.assertEqual(rounded, IntermediateForm.from_str(expected))
 
-    def test_minimum_exponent_and_maximum_figures(self):
-        format = TargetFormat(
-            maximum_figures=4,
-            minimum_exponent=-2
-        )
+    def test_minimum_exponent_and_maximum_figures(self) -> None:
+        format = TargetFormat(maximum_figures=4, minimum_exponent=-2)
 
         # Pairs (value, mode, expected)
         test_values = [
@@ -124,9 +170,57 @@ class TestRoundForFormat(unittest.TestCase):
             (23.14159, TIES_TO_EVEN, "23.14"),
             (123.14159, TIES_TO_EVEN, "123.1"),
             (6123.14159, TIES_TO_EVEN, "6123"),
+            # Zeros: constrained by minimum exponent.
+            (0.0, TIES_TO_EVEN, "0.00"),
+            (-0.0, TIES_TO_EVEN, "-0.00"),
+            # Near zero
+            (0.006, TIES_TO_EVEN, "0.01"),
+            (0.004, TIES_TO_EVEN, "0.00"),
+            (0.0004, TIES_TO_EVEN, "0.00"),
+            (4e-10, TIES_TO_EVEN, "0.00"),
+            (-0.004, TIES_TO_EVEN, "-0.00"),
         ]
 
         for unrounded, mode, expected in test_values:
             with self.subTest(unrounded=unrounded, mode=mode):
-                rounded = round_to_format(unrounded, format=format, mode=mode)
+                rounded = round_for_format(unrounded, format=format, mode=mode)
                 self.assertEqual(rounded, IntermediateForm.from_str(expected))
+
+    def test_neither_minimum_exponent_nor_maximum_figures(self) -> None:
+        format = TargetFormat()
+
+        test_values = [
+            (1.0, TIES_TO_EVEN, "1"),
+            (fractions.Fraction(3, 8), TIES_TO_EVEN, "0.375"),
+            (fractions.Fraction(3, 40), TIES_TO_EVEN, "0.075"),
+            (fractions.Fraction(3, 125), TIES_TO_EVEN, "0.024"),
+            (1230, TIES_TO_EVEN, "1230"),
+        ]
+
+        for unrounded, mode, expected in test_values:
+            with self.subTest(unrounded=unrounded, mode=mode):
+                rounded = round_for_format(unrounded, format=format, mode=mode)
+                self.assertEqual(rounded, IntermediateForm.from_str(expected))
+
+        bad_values = [
+            fractions.Fraction(1, 3),
+            fractions.Fraction(1, 300),
+        ]
+        for value in bad_values:
+            with self.assertRaises(ValueError):
+                round_for_format(value, format=format, mode=TIES_TO_EVEN)
+
+    def test__smallest_ten_power_multiple(self) -> None:
+        for etwo in range(100):
+            for efive in range(100):
+                d = 2**etwo * 5**efive
+                self.assertEqual(_smallest_ten_power_multiple(d), max(etwo, efive))
+
+        bad = [n for n in range(2, 1000) if math.gcd(n, 10) == 1]
+
+        for etwo in range(10):
+            for efive in range(10):
+                for b in bad:
+                    d = b * 2**etwo * 5**efive
+                    with self.assertRaises(ValueError):
+                        _smallest_ten_power_multiple(d)

--- a/src/rounders/test/test_round_for_format.py
+++ b/src/rounders/test/test_round_for_format.py
@@ -3,6 +3,7 @@ Tests for round_for_format.
 """
 
 import dataclasses
+import decimal
 import fractions
 import math
 import unittest
@@ -195,6 +196,7 @@ class TestRoundForFormat(unittest.TestCase):
             (fractions.Fraction(3, 40), TIES_TO_EVEN, "0.075"),
             (fractions.Fraction(3, 125), TIES_TO_EVEN, "0.024"),
             (1230, TIES_TO_EVEN, "1230"),
+            (decimal.Decimal("123e4"), TIES_TO_EVEN, "123e4"),
         ]
 
         for unrounded, mode, expected in test_values:


### PR DESCRIPTION
[Pushing an ancient branch to GitHub, for self-review purposes]

This PR adds support for formatting in the case where both `format.maximum_figures` and `format.minimum_exponent` are `None`. In that case, formatting should either give a representation of the exact value, or it should fail.

## Detailed changes 

- support the formatting case where both `format.maximum_figures` and `format.minimum_exponent` are `None`: in that case, formatting should either give a representation of the exact value, or fail
- support an exponent of `None` in `IntermediateForm.from_signed_fraction`
- make exponent optional in `preround`: if `exponent` is `None`, then either an exact conversion to the intermediate form is performed, or if that isn't possible, `ValueError` is raised.
