### PR TITLE
Update minimum Python version to 3.8; test on 3.12 and 3.13

### DIFF
--- a/.github/workflows/qc.yaml
+++ b/.github/workflows/qc.yaml
@@ -11,13 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         cache: 'pip'
         cache-dependency-path: '.github/workflows/qc-requirements.txt'
     - run: python -m pip install -r .github/workflows/qc-requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = 'rounders'
 version = '0.1.0'
 description = 'round-function equivalents with different rounding-modes'
 readme = 'README.md'
-requires-python = '>=3.7'
+requires-python = '>=3.8'
 authors = [{name = 'Mark Dickinson', email = 'dickinsm@gmail.com'}]
 keywords = ['round', 'rounding', 'significant figures', 'decimal places', 'rounding mode']
 classifiers = [


### PR DESCRIPTION
This PR bumps the minimum Python required version to 3.8, and updates the CI workflow to add tests on Python 3.12 and Python 3.13.