### PR TITLE
Switch to ruff for formatting and linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203
-exclude =
-    build

--- a/.github/workflows/qc-requirements.txt
+++ b/.github/workflows/qc-requirements.txt
@@ -2,8 +2,6 @@
 # every few months or so, so that the cache is regenerated with the latest
 # packages.
 # --> 000 <---
-black
-flake8
-isort
 mypy
 pytest
+ruff

--- a/.github/workflows/qc.yaml
+++ b/.github/workflows/qc.yaml
@@ -24,9 +24,8 @@ jobs:
     - run: python -m pip install .
     - name: Run style checks
       run: |
-        python -m isort --check --diff .
-        python -m black --check --diff .
+        python -m ruff format --check --diff
+        python -m ruff check
         python -m mypy --strict .
-        python -m flake8 .
     - name: Run test suite
       run: python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,6 @@ profile = 'black'
 exclude = [
     'build/',
 ]
+
+[tool.ruff.lint]
+extend-select = ["I"]


### PR DESCRIPTION
This PR replaces use of `black`, `flake8` and `isort` with `ruff`.