### PR TITLE
Add setuptools_scm for versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,35 +1,35 @@
+[build-system]
+requires = ['setuptools>=70', 'setuptools_scm>=8']
+build-backend = 'setuptools.build_meta'
+
 [project]
 name = 'rounders'
-version = '0.1.0'
 description = 'round-function equivalents with different rounding-modes'
 readme = 'README.md'
 requires-python = '>=3.8'
-authors = [{name = 'Mark Dickinson', email = 'dickinsm@gmail.com'}]
-keywords = ['round', 'rounding', 'significant figures', 'decimal places', 'rounding mode']
+authors = [{ name = 'Mark Dickinson', email = 'dickinsm@gmail.com' }]
+keywords = [
+    'round',
+    'rounding',
+    'significant figures',
+    'decimal places',
+    'rounding mode',
+]
 classifiers = [
     'License :: OSI Approved :: Apache Software License',
     'Operating System :: OS Independent',
     'Programming Language :: Python :: 3',
     'Topic :: Scientific/Engineering :: Mathematics',
 ]
+dynamic = ["version"]
 
 [project.urls]
 source = 'https://github.com/mdickinson/rounders'
 
-[build-system]
-requires = ['setuptools>=42', 'wheel']
-build-backend = 'setuptools.build_meta'
-
-[tool.black]
-target-version = ['py37']
-
-[tool.isort]
-profile = 'black'
-
 [tool.mypy]
-exclude = [
-    'build/',
-]
+exclude = ['build/']
 
 [tool.ruff.lint]
 extend-select = ["I"]
+
+[tool.setuptools_scm]


### PR DESCRIPTION
This PR introduces use of `setuptools_scm` for versioning. It also tidies up the `pyproject.toml` a bit, removing outdated configs for `isort` and `black`, and reformatting some entries.