### PR TITLE
Use release-branch-semver versioning scheme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,4 @@ exclude = ['build/']
 extend-select = ["I"]
 
 [tool.setuptools_scm]
+version_scheme = "release-branch-semver"


### PR DESCRIPTION
Use the release-branch-semver versioning scheme, to get sensible versions from commits on the main branch.