### PR TITLE
Don't use a shallow clone, so that we get the correct version

### DIFF
--- a/.github/workflows/qc.yaml
+++ b/.github/workflows/qc.yaml
@@ -11,22 +11,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
-        cache: 'pip'
-        cache-dependency-path: '.github/workflows/qc-requirements.txt'
-    - run: python -m pip install -r .github/workflows/qc-requirements.txt
-    - run: python -m pip install .
-    - name: Run style checks
-      run: |
-        python -m ruff format --check --diff
-        python -m ruff check
-        python -m mypy --strict .
-    - name: Run test suite
-      run: python -m pytest
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+          cache: "pip"
+          cache-dependency-path: ".github/workflows/qc-requirements.txt"
+      - run: python -m pip install -r .github/workflows/qc-requirements.txt
+      - run: python -m pip install .
+      - name: Run style checks
+        run: |
+          python -m ruff format --check --diff
+          python -m ruff check
+          python -m mypy --strict .
+      - name: Run test suite
+        run: python -m pytest


### PR DESCRIPTION
Just to make sure that setuptools-scm is working as expected in the workflow build. The repository is fairly tiny, so there's not much of a cost involved in making a full clone each time.