### PR TITLE
Give RoundingMode a more useful repr

### DIFF
--- a/changelog.d/20240608_172515_dickinsm.md
+++ b/changelog.d/20240608_172515_dickinsm.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+### Changed
+
+- Rounding modes now have a more user-friendly representation.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/doc/todo.txt
+++ b/doc/todo.txt
@@ -1,8 +1,6 @@
 To-do list
 ----------
 
-- Add names to the standard rounding modes so that their representations are
-  pleasanter. (Currently looks like 'standard_rounding_mode.<locals>.round_decide.)
 - Formatting:
   - Consider implementing __format__ on the intermediate representation.
   - Make precision optional

--- a/src/rounders/modes.py
+++ b/src/rounders/modes.py
@@ -141,13 +141,21 @@ class _RoundForReroundRoundingMode(RoundingMode):
 TO_ZERO_05_AWAY: RoundingMode = _RoundForReroundRoundingMode()
 
 #: To-nearest rounding modes.
-TIES_TO_ZERO: RoundingMode = _StandardRoundingMode(((4, 4), (4, 4)), name="ties to zero")
-TIES_TO_AWAY: RoundingMode = _StandardRoundingMode(((5, 5), (5, 5)), name="ties to away")
+TIES_TO_ZERO: RoundingMode = _StandardRoundingMode(
+    ((4, 4), (4, 4)), name="ties to zero"
+)
+TIES_TO_AWAY: RoundingMode = _StandardRoundingMode(
+    ((5, 5), (5, 5)), name="ties to away"
+)
 TIES_TO_MINUS: RoundingMode = _StandardRoundingMode(
     ((4, 4), (5, 5)), name="ties to minus"
 )
-TIES_TO_PLUS: RoundingMode = _StandardRoundingMode(((5, 5), (4, 4)), name="ties to plus")
-TIES_TO_EVEN: RoundingMode = _StandardRoundingMode(((4, 5), (4, 5)), name="ties to even")
+TIES_TO_PLUS: RoundingMode = _StandardRoundingMode(
+    ((5, 5), (4, 4)), name="ties to plus"
+)
+TIES_TO_EVEN: RoundingMode = _StandardRoundingMode(
+    ((4, 5), (4, 5)), name="ties to even"
+)
 TIES_TO_ODD: RoundingMode = _StandardRoundingMode(((5, 4), (5, 4)), name="ties to odd")
 
 #: Directed rounding modes.


### PR DESCRIPTION
This PR updates the repr of the various rounding modes.

Before:
```python
Python 3.12.3 (main, Apr 12 2024, 17:19:53) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from rounders import *
>>> TO_EVEN
<rounders.modes._StandardRoundingMode object at 0x10ea66c00>
>>> TIES_TO_AWAY
<rounders.modes._StandardRoundingMode object at 0x10ea66a80>
>>> TO_ZERO_05_AWAY
<rounders.modes._RoundForReroundRoundingMode object at 0x10ea66930>
```

After:
```python
Python 3.12.3 (main, Apr 12 2024, 17:19:53) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from rounders import *
>>> TO_EVEN
<RoundingMode: to even>
>>> TIES_TO_AWAY
<RoundingMode: ties to away>
>>> TO_ZERO_05_AWAY
<RoundingMode: to zero (05 away)>
```
