### PR TITLE
Add RoundingMode to the exports

### DIFF
--- a/changelog.d/20240608_193249_dickinsm_add_rounding_mode_to_api.md
+++ b/changelog.d/20240608_193249_dickinsm_add_rounding_mode_to_api.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+### Added
+
+- Added the `RoundingMode` type to the top-level exports, since it's potentially
+  useful for type hints in client code.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/rounders/__init__.py
+++ b/src/rounders/__init__.py
@@ -33,6 +33,7 @@ from rounders.modes import (
     TO_PLUS,
     TO_ZERO,
     TO_ZERO_05_AWAY,
+    RoundingMode,
 )
 from rounders.round_to import round, round_to_figures, round_to_int, round_to_places
 
@@ -64,6 +65,8 @@ __all__ = [
     "ceil",
     "floor",
     "trunc",
+    # Rounding mode type
+    "RoundingMode",
     # Rounding modes - to-nearest
     "TIES_TO_AWAY",
     "TIES_TO_EVEN",


### PR DESCRIPTION
`RoundingMode` was missing from the top-level `__init__.py`. It should be there, so that client code can import it for use in type hints.