### PR TITLE
Remove quotes around types

### DIFF
--- a/src/rounders/format.py
+++ b/src/rounders/format.py
@@ -1,5 +1,7 @@
 """Formatting functionality."""
 
+from __future__ import annotations
+
 import dataclasses
 import re
 from typing import Any, Dict, Optional
@@ -175,7 +177,7 @@ class FormatSpecification:
         return sign_str + before_point + point + after_point + exponent
 
     @classmethod
-    def from_string(cls, pattern: str) -> "FormatSpecification":
+    def from_string(cls, pattern: str) -> FormatSpecification:
         """
         Create a format specification from a format specification string.
 

--- a/src/rounders/intermediate.py
+++ b/src/rounders/intermediate.py
@@ -1,5 +1,7 @@
 """Representations of intermediate values."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, replace
 from typing import cast
 
@@ -29,7 +31,7 @@ class IntermediateForm:
     @classmethod
     def from_signed_fraction(
         cls, *, sign: int, numerator: int, denominator: int, exponent: int
-    ) -> "IntermediateForm":
+    ) -> IntermediateForm:
         """
         Create from a signed fraction, given a target exponent.
 
@@ -49,7 +51,7 @@ class IntermediateForm:
             exponent=exponent,
         )
 
-    def nudge(self, figures: int) -> "IntermediateForm":
+    def nudge(self, figures: int) -> IntermediateForm:
         """Drop a zero in cases where rounding led us to end up with an extra zero."""
         if len(str(self.significand)) != figures + 1:
             return self
@@ -66,7 +68,7 @@ class IntermediateForm:
             exponent=self.exponent + 1,
         )
 
-    def round(self, exponent: int, mode: RoundingMode) -> "IntermediateForm":
+    def round(self, exponent: int, mode: RoundingMode) -> IntermediateForm:
         """Round to the given exponent, using the given rounding mode."""
         diff = self.exponent - exponent
         if diff >= 0:


### PR DESCRIPTION
Typing nitpick: use `from __future__ import annotations` where relevant so that we can drop quoting of return types.