### PR TITLE
Add configuration for coverage tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ dynamic = ["version"]
 [project.urls]
 source = 'https://github.com/mdickinson/rounders'
 
+[tool.coverage.run]
+branch = true
+source_pkgs = ["rounders"]
+
 [tool.mypy]
 exclude = ['build/']
 


### PR DESCRIPTION
This PR adds a basic configuration for coverage, so that `coverage run -m pytest`:

- always runs branch coverage
- measures all files in the package, even if they're not touched by the test suite
