### PR TITLE
Add IntermediateForm.from_str

### DIFF
--- a/changelog.d/20240616_121201_dickinsm_intermediate_form_from_str.md
+++ b/changelog.d/20240616_121201_dickinsm_intermediate_form_from_str.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- New method `IntermediateForm.from_str`, mostly for easy creation of `IntermediateForm`
+  instances for test purposes. The required format is currently quite strict.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/rounders/intermediate.py
+++ b/src/rounders/intermediate.py
@@ -49,7 +49,7 @@ class IntermediateForm:
         strict about input format.
         """
         if (match := _INTERMEDIATE_FORM_PATTERN.fullmatch(s)) is None:
-            raise ValueError(f"Invalid numeric string: {s}")
+            raise ValueError(f"invalid numeric string: {s}")
 
         fracpart = match["fracpart"] or ""
         return cls(

--- a/src/rounders/intermediate.py
+++ b/src/rounders/intermediate.py
@@ -2,10 +2,22 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, replace
 from typing import cast
 
 from rounders.modes import RoundingMode
+
+#: Pattern for string representation of an intermediate form value.
+_INTERMEDIATE_FORM_PATTERN = re.compile(
+    r"""
+    (?P<sign>-?)
+    (?P<intpart>[0-9]+)
+    (\.(?P<fracpart>[0-9]+))?
+    (e(?P<exponent>-?[0-9]+))?
+    """,
+    re.VERBOSE,
+)
 
 
 @dataclass(frozen=True)
@@ -27,6 +39,24 @@ class IntermediateForm:
 
     # Exponent
     exponent: int
+
+    @classmethod
+    def from_str(cls, s: str) -> IntermediateForm:
+        """
+        Create an intermediate form from a string.
+
+        This is currently aimed at test convenience rather than users, and so is rather
+        strict about input format.
+        """
+        if (match := _INTERMEDIATE_FORM_PATTERN.fullmatch(s)) is None:
+            raise ValueError(f"Invalid numeric string: {s}")
+
+        fracpart = match["fracpart"] or ""
+        return cls(
+            sign=1 if match["sign"] == "-" else 0,
+            significand=int(match["intpart"] + fracpart),
+            exponent=int(match["exponent"] or 0) - len(fracpart),
+        )
 
     @classmethod
     def from_signed_fraction(

--- a/src/rounders/test/test_intermediate_form.py
+++ b/src/rounders/test/test_intermediate_form.py
@@ -8,7 +8,7 @@ from rounders.intermediate import IntermediateForm
 class TestIntermediateForm(unittest.TestCase):
     """Tests for the IntermediateForm class."""
 
-    def test_from_str(self):
+    def test_from_str(self) -> None:
         # Tuples (input, sign, significand, exponent)
         cases = [
             ("2e3", 0, 2, 3),

--- a/src/rounders/test/test_intermediate_form.py
+++ b/src/rounders/test/test_intermediate_form.py
@@ -1,0 +1,43 @@
+"""Tests for the IntermediateForm class."""
+
+import unittest
+
+from rounders.intermediate import IntermediateForm
+
+
+class TestIntermediateForm(unittest.TestCase):
+    """Tests for the IntermediateForm class."""
+
+    def test_from_str(self):
+        # Tuples (input, sign, significand, exponent)
+        cases = [
+            ("2e3", 0, 2, 3),
+            # Negative value
+            ("-2e3", 1, 2, 3),
+            # Decimal point in significand
+            ("1.234e3", 0, 1234, 0),
+            ("0.0001e-3", 0, 1, -7),
+            # Safeguard against converting fracpart to an int
+            ("1.0234e3", 0, 10234, -1),
+            # Negative sign on exponent
+            ("78e-3", 0, 78, -3),
+            # No exponent
+            ("1.234", 0, 1234, -3),
+            # Zeros
+            ("0e0", 0, 0, 0),
+            ("-0e0", 1, 0, 0),
+            ("000e0", 0, 0, 0),
+            ("000e-3", 0, 0, -3),
+            ("-0.000e12", 1, 0, 9),
+        ]
+
+        for s, sign, significand, exponent in cases:
+            with self.subTest(s=s):
+                self.assertEqual(
+                    IntermediateForm.from_str(s),
+                    IntermediateForm(
+                        sign=sign,
+                        significand=significand,
+                        exponent=exponent,
+                    ),
+                )


### PR DESCRIPTION
This PR adds an `IntermediateForm.from_str` method, with the goal of making it easier to create `IntermediateForm` objects for use in unit tests.