### PR TITLE
Allow decade to be an underestimate

### DIFF
--- a/changelog.d/20240616_152511_dickinsm_weaken_decade_requirement.md
+++ b/changelog.d/20240616_152511_dickinsm_weaken_decade_requirement.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- Two properties have been added to the `IntermediateForm` class: `decade` and
+  `figures`.
+
+### Changed
+
+- The requirements on overloads for the `decade` generic have been weakened. Overloads
+  need not compute the exact decade, but merely need to supply a lower bound for the
+  decade.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/rounders/generics.py
+++ b/src/rounders/generics.py
@@ -11,8 +11,10 @@ def decade(x: Any) -> int:
     """
     Determine the decade that a nonzero number is contained in.
 
-    Given nonzero finite x, returns the unique integer e satisfying
-    10**e <= abs(x) < 10**(e + 1).
+    The decade of x is the unique integer e satisfying 10**e <= abs(x) < 10**(e + 1).
+    Where the decade is expensive to compute, it's enough for the overloads to return a
+    lower bound for the decade: an integer e such that 10**e <= abs(x). This causes some
+    extra work during rounding.
     """
     raise NotImplementedError(f"No overload available for type {type(x)}")
 

--- a/src/rounders/intermediate.py
+++ b/src/rounders/intermediate.py
@@ -126,9 +126,25 @@ class IntermediateForm:
             exponent=exponent,
         )
 
+    @property
+    def figures(self) -> int:
+        """
+        Number of decimal digits in the significand.
+
+        Returns zero if the significand is zero.
+        """
+        return len(str(self.significand)) if self.significand != 0 else 0
+
+    @property
+    def decade(self) -> int:
+        """Return an integer e such that 10**e <= abs(self) < 10**(e+1)."""
+        if self.significand == 0:
+            raise ValueError(f"zero value {self} has no decade")
+        return self.exponent + self.figures - 1
+
     def nudge(self, figures: int) -> IntermediateForm:
         """Drop a zero in cases where rounding led us to end up with an extra zero."""
-        if len(str(self.significand)) != figures + 1:
+        if self.figures != figures + 1:
             return self
 
         new_significand, tenths = divmod(self.significand, 10)

--- a/src/rounders/round_to.py
+++ b/src/rounders/round_to.py
@@ -86,8 +86,8 @@ def round_to_figures(x: Any, figures: int, *, mode: RoundingMode = TIES_TO_EVEN)
     #  1.23e+02
     #  0.00e+00
 
-    exponent = (0 if is_zero(x) else decade(x)) + 1 - figures
-    prerounded = preround(x, exponent)
+    prerounded = preround(x, exponent=None if is_zero(x) else decade(x) + 1 - figures)
+    exponent = (0 if is_zero(x) else prerounded.decade) + 1 - figures
     rounded = prerounded.round(exponent, mode)
 
     # Adjust if the result has one more significant figure than expected.


### PR DESCRIPTION
This PR weakens the requirements on `decade` overloads: overloads may return an underestimate for the decade in situations where it's computationally expensive to determine the exact decade.