### PR TITLE
Replace IntermediateForm.nudge with more general IntermediateForm.trim

### DIFF
--- a/changelog.d/20240629_165752_dickinsm.md
+++ b/changelog.d/20240629_165752_dickinsm.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+
+### Removed
+
+- Removed `IntermediateForm.nudge`; use `IntermediateForm.trim` instead.
+
+
+
+### Added
+
+- Added `IntermediateForm.trim` method, a more general version of
+  `IntermediateForm.nudge`.
+
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/rounders/format.py
+++ b/src/rounders/format.py
@@ -270,7 +270,7 @@ def format(value: Any, pattern: str) -> str:
     rounded = prerounded.round(exponent, format_specification.rounding_mode)
     if format_specification.figures is not None:
         # Adjust if necessary.
-        rounded = rounded.nudge(format_specification.figures)
+        rounded = rounded.trim(format_specification.figures)
 
     # Step 2: convert to string. Only supporting e and f-presentation formats right now.
     return format_specification.format(rounded)

--- a/src/rounders/intermediate_form.py
+++ b/src/rounders/intermediate_form.py
@@ -146,21 +146,23 @@ class IntermediateForm:
         """Return True if value is zero, else False."""
         return self.significand == 0
 
-    def nudge(self, figures: int) -> IntermediateForm:
-        """Drop a zero in cases where rounding led us to end up with an extra zero."""
-        if self.figures != figures + 1:
+    def trim(self, figures: int) -> IntermediateForm:
+        """
+        Trim to a given number of significant figures by removing trailing zeros.
+
+        Raises ValueError if trimming would involve removing non-zero digits.
+        """
+        diff = self.figures - figures
+        if diff <= 0:
             return self
 
-        new_significand, tenths = divmod(self.significand, 10)
-        if tenths:
-            raise ValueError(
-                "Last digit is nonzero; dropping it would change the value"
-            )
-
+        new_significand, remainder = divmod(self.significand, 10**diff)
+        if remainder:
+            raise ValueError("trim would remove nonzero digits")
         return replace(
             self,
             significand=new_significand,
-            exponent=self.exponent + 1,
+            exponent=self.exponent + diff
         )
 
     def round(self, exponent: int, mode: RoundingMode) -> IntermediateForm:

--- a/src/rounders/intermediate_form.py
+++ b/src/rounders/intermediate_form.py
@@ -159,11 +159,7 @@ class IntermediateForm:
         new_significand, remainder = divmod(self.significand, 10**diff)
         if remainder:
             raise ValueError("trim would remove nonzero digits")
-        return replace(
-            self,
-            significand=new_significand,
-            exponent=self.exponent + diff
-        )
+        return replace(self, significand=new_significand, exponent=self.exponent + diff)
 
     def round(self, exponent: int, mode: RoundingMode) -> IntermediateForm:
         """Round to the given exponent, using the given rounding mode."""

--- a/src/rounders/round_to.py
+++ b/src/rounders/round_to.py
@@ -94,7 +94,7 @@ def round_to_figures(x: Any, figures: int, *, mode: RoundingMode = TIES_TO_EVEN)
     # This can happen when a value at the uppermost end of a decade gets
     # rounded up to the next power of 10: for example, in rounding
     # 99.973 to 100.0.
-    rounded = rounded.nudge(figures)
+    rounded = rounded.trim(figures)
     return to_type_of(x, rounded)
 
 

--- a/src/rounders/test/test_intermediate_form.py
+++ b/src/rounders/test/test_intermediate_form.py
@@ -99,3 +99,34 @@ class TestIntermediateForm(unittest.TestCase):
 
         self.assertFalse(IntermediateForm.from_str("1.23").is_zero())
         self.assertFalse(IntermediateForm.from_str("-1.23").is_zero())
+
+    def test_trim(self) -> None:
+        # Triples (input, figures, result)
+        test_cases = [
+            ("1.230", 3, "1.23"),
+            ("0.0001230", 3, "0.000123"),
+            ("1230", 3, "123e1"),
+            ("1.2", 3, "1.2"),
+            ("1.200", 3, "1.20"),
+            ("1.2000", 3, "1.20"),
+            ("1.2000000", 3, "1.20"),
+            ("0.0000", 3, "0.0000"),
+        ]
+        for input_str, figures, expected_result_str in test_cases:
+            with self.subTest(input=input_str, figures=figures):
+                input = IntermediateForm.from_str(input_str)
+                expected_result = IntermediateForm.from_str(expected_result_str)
+                self.assertEqual(input.trim(figures), expected_result)
+
+    def test_trim_invalid(self) -> None:
+        # Pairs (input, figures)
+        test_cases = [
+            ("1.234", 3),
+            ("1.2345", 3),
+            ("1", 0),
+        ]
+        for input_str, figures in test_cases:
+            with self.subTest(input=input_str, figures=figures):
+                input = IntermediateForm.from_str(input_str)
+                with self.assertRaises(ValueError):
+                    input.trim(figures)


### PR DESCRIPTION
Minor update to replace `IntermediateForm.nudge` with something more general (and better named).