### PR TITLE
Add IntermediateForm.__str__

### DIFF
--- a/src/rounders/intermediate_form.py
+++ b/src/rounders/intermediate_form.py
@@ -188,3 +188,7 @@ class IntermediateForm:
         if self.exponent != 0:
             raise ValueError("can only convert a value with exponent 0 to an integer")
         return -self.significand if self.sign else self.significand
+
+    def __str__(self) -> str:
+        """Return a simple string representation of an intermediate form."""
+        return f"{'-' * self.sign}{self.significand}e{self.exponent}"

--- a/src/rounders/test/test_intermediate_form.py
+++ b/src/rounders/test/test_intermediate_form.py
@@ -130,3 +130,18 @@ class TestIntermediateForm(unittest.TestCase):
                 input = IntermediateForm.from_str(input_str)
                 with self.assertRaises(ValueError):
                     input.trim(figures)
+
+    def test_str(self) -> None:
+        # Pairs (input, output)
+        test_cases = [
+            ("1.234", "1234e-3"),
+            ("1.2345", "12345e-4"),
+            ("1", "1e0"),
+            ("-123", "-123e0"),
+            ("0.000", "0e-3"),
+        ]
+
+        for input_str, expected in test_cases:
+            with self.subTest(input=input_str):
+                input = IntermediateForm.from_str(input_str)
+                self.assertEqual(str(input), expected)


### PR DESCRIPTION
Add a simple string representation for `IntermediateForm`, with tests.