### PR TITLE
Clarify docstring for IntermediateForm

### DIFF
--- a/src/rounders/intermediate_form.py
+++ b/src/rounders/intermediate_form.py
@@ -59,7 +59,7 @@ class IntermediateForm:
     # 1 for negative, 0 for positive
     sign: int
 
-    # Significand
+    # Significand: a nonnegative integer
     significand: int
 
     # Exponent


### PR DESCRIPTION
Drive-by annotation to clarify that `IntermediateForm.significand` must always be nonnegative.