### PR TITLE
Implement formatting for zeros

### DIFF
--- a/src/rounders/format.py
+++ b/src/rounders/format.py
@@ -105,9 +105,6 @@ class FormatSpecification:
     #: Sign to use for positive values.
     positive_sign: str = ""
 
-    #: Exponent to use for zero.
-    exponent_for_zero: int = 0
-
     @classmethod
     def from_str(cls, pattern: str) -> FormatSpecification:
         """
@@ -132,10 +129,7 @@ class FormatSpecification:
         round_type = match["type"]
         if round_type == "f":
             places = int(match["precision"])
-            kwargs.update(
-                places=places,
-                exponent_for_zero=-places,
-            )
+            kwargs.update(places=places)
         elif round_type == "e":
             kwargs.update(figures=int(match["precision"]) + 1)
             kwargs.update(scientific=True)
@@ -170,6 +164,21 @@ class FormatSpecification:
             signed_zero=self.signed_zero,
         )
 
+    @property
+    def zero_exponent(self) -> int | None:
+        """
+        Exponent to use when formatting zeros.
+
+        A return value of None indicates that the existing exponent should be passed
+        through.
+        """
+        exponents: list[int] = []
+        if self.places is not None:
+            exponents.append(-self.places)
+        if self.figures is not None:
+            exponents.append(1 - self.figures)
+        return max(exponents, default=None)
+
     def format(self, rounded: IntermediateForm) -> str:
         """
         Format a decimal object in intermediate form using this format specification.
@@ -189,16 +198,13 @@ class FormatSpecification:
 
         # Adjust for scientific notation
         use_exponent = self.scientific
-        if use_exponent:
-            if not rounded.significand:
-                # Q: What should the displayed exponent be in this case?
-                raise NotImplementedError("later")
-
+        if use_exponent and rounded.significand:
             # Nonzero value: place the decimal point after the
             # first digit.
             e_exponent = rounded.exponent + len(digits) - 1
             end_exponent = rounded.exponent - e_exponent
         else:
+            e_exponent = 0
             end_exponent = rounded.exponent
 
         # Figure out number-line positions.
@@ -238,7 +244,7 @@ def round_for_format(
     *,
     format: TargetFormat,
     mode: RoundingMode,
-    zero_exponent: int,
+    zero_exponent: int | None,
 ) -> IntermediateForm:
     """
     Round a finite value to a given target format, using a given rounding mode.
@@ -290,7 +296,7 @@ def format(value: Any, pattern: str) -> str:
         value,
         format=format_specification.target_format,
         mode=format_specification.rounding_mode,
-        zero_exponent=format_specification.exponent_for_zero,
+        zero_exponent=format_specification.zero_exponent,
     )
 
     # Step 2: convert to string. Only supporting e and f-presentation formats right now.

--- a/src/rounders/test/test_format.py
+++ b/src/rounders/test/test_format.py
@@ -94,6 +94,11 @@ class TestFormat(unittest.TestCase):
             ("0.996", ".1e", "1.0e0"),
             ("3.14159", ".0e", "3e0"),
             ("3.14159", "#.0e", "3.e0"),
+            # Formatting zeros
+            ("0", ".2e", "0.00e0"),
+            ("0", ".1e", "0.0e0"),
+            ("0", ".0e", "0e0"),
+            ("0", "#.0e", "0.e0"),
         ]
         self.check_cases(cases)
 


### PR DESCRIPTION
This PR implements formatting for zeros. The hard part of this is deciding what exponent to use.

For fixed-precision formatting, the choice is clear: we use the same target exponent when formatting both nonzero and zero numbers.

For formatting a zero to a given number of significant digits, we choose the exponent so that the formatted output has the expected number of significant digits and so that in scientific notation the exponent would be zero. So for example when formatting to 3 significant digits, any zero ends up as `0.00`, or equivalently `0.00e+0`.

If targeting a format that has both a limit on the number of significant digits _and_ on the precision, we take the max of the implied exponents. So for example if `places = 3` and `figures = 5`, the result is `0.000` rather than `0.0000`. This works well for the particular case `places = 0`, where all target values are integral.