### PR TITLE
Make 'digits' a property of IntermediateForm

### DIFF
--- a/src/rounders/format.py
+++ b/src/rounders/format.py
@@ -190,9 +190,10 @@ class FormatSpecification:
             The formatted value.
         """
         # Get digits as a decimal string.
-        digits = str(rounded.significand) if rounded.significand else ""
+        digits = rounded.digits
 
-        # Adjust for scientific notation
+        # Adjust for scientific notation. e_exponent is the value that will appear after
+        # the 'e' in the formatted result.
         use_exponent = self.scientific
         if use_exponent and rounded.significand:
             # Nonzero value: place the decimal point after the first digit.

--- a/src/rounders/format.py
+++ b/src/rounders/format.py
@@ -189,21 +189,35 @@ class FormatSpecification:
         str
             The formatted value.
         """
-        # Get digits as a decimal string.
+        # Get necessary attributes.
         digits = rounded.digits
+        low_exponent = rounded.exponent
+        high_exponent = rounded.exponent + len(digits)
+        sign = rounded.sign
 
         # Adjust for scientific notation. e_exponent is the value that will appear after
         # the 'e' in the formatted result.
         use_exponent = self.scientific
-        if use_exponent and rounded.significand:
-            # Nonzero value: place the decimal point after the first digit.
-            e_exponent = rounded.exponent + len(digits) - 1
+        if use_exponent:
+            if digits:
+                # Nonzero value: place the decimal point after the first digit.
+                e_exponent = low_exponent + len(digits) - 1
+            else:
+                # XXX Can we somehow eliminate this special case?
+                # Only by altering digits in the case of significand zero ...
+                if low_exponent <= 0:
+                    digits = "0" * (1 - low_exponent)
+                    high_exponent = 1
+                    e_exponent = low_exponent + len(digits) - 1
+                else:
+                    assert False, "never get here"
+                    e_exponent = 0
         else:
             e_exponent = 0
 
         # Figure out number-line positions.
-        end_exponent = rounded.exponent - e_exponent
-        start_exponent = end_exponent + len(digits)
+        start_exponent = high_exponent - e_exponent
+        end_exponent = low_exponent - e_exponent
 
         # Pad with zeros to ensure required minimum number of digits before and
         # after the point.
@@ -217,7 +231,7 @@ class FormatSpecification:
             end_exponent = -self.min_digits_after_point
 
         # Determine the string to use to represent the sign.
-        sign_str = self.negative_sign if rounded.sign else self.positive_sign
+        sign_str = self.negative_sign if sign else self.positive_sign
 
         # Assemble the result.
         before_point = digits[:start_exponent]

--- a/src/rounders/format.py
+++ b/src/rounders/format.py
@@ -184,28 +184,14 @@ class FormatSpecification:
             The formatted value.
         """
         # Get necessary attributes.
-        digits = rounded.digits
-        low_exponent = rounded.exponent
+        digits, low_exponent, sign = rounded.digits, rounded.exponent, rounded.sign
         high_exponent = rounded.exponent + len(digits)
-        sign = rounded.sign
 
         # Adjust for scientific notation. e_exponent is the value that will appear after
         # the 'e' in the formatted result.
         use_exponent = self.scientific
-        if use_exponent:
-            if digits:
-                # Nonzero value: place the decimal point after the first digit.
-                e_exponent = low_exponent + len(digits) - 1
-            else:
-                # XXX Can we somehow eliminate this special case?
-                # Only by altering digits in the case of significand zero ...
-                if low_exponent <= 0:
-                    digits = "0" * (1 - low_exponent)
-                    high_exponent = 1
-                    e_exponent = low_exponent + len(digits) - 1
-                else:
-                    assert False, "never get here"
-                    e_exponent = 0
+        if use_exponent and digits:
+            e_exponent = low_exponent + len(digits) - 1
         else:
             e_exponent = 0
 

--- a/src/rounders/intermediate_form.py
+++ b/src/rounders/intermediate_form.py
@@ -65,6 +65,14 @@ class IntermediateForm:
     # Exponent
     exponent: int
 
+    @property
+    def digits(self) -> str:
+        """Return the digits of the significand.
+
+        Returns an empty string for the case significand = 0.
+        """
+        return str(self.significand) if self.significand else ""
+
     @classmethod
     def from_str(cls, s: str) -> IntermediateForm:
         """


### PR DESCRIPTION
Minor refactor to make `digits` a property of `IntermediateForm`. The idea is that formatting cares only about an interface that exposes `digits`, `exponent` and `sign`, and not about `significand`.