### PR TITLE
Make dataclasses keyword-only

### DIFF
--- a/src/rounders/format.py
+++ b/src/rounders/format.py
@@ -62,7 +62,7 @@ _MODE_FORMAT_CODES = {
 }
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class FormatSpecification:
     """Description of a format specification."""
 

--- a/src/rounders/intermediate_form.py
+++ b/src/rounders/intermediate_form.py
@@ -25,7 +25,7 @@ _INTERMEDIATE_FORM_PATTERN = re.compile(
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class IntermediateForm:
     """
     Intermediate value for rounding and formatting operations.

--- a/src/rounders/target_format.py
+++ b/src/rounders/target_format.py
@@ -3,7 +3,7 @@
 import dataclasses
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class TargetFormat:
     """
     Class representing a target format for a rounding operation.


### PR DESCRIPTION
A minor modernization: now that we only support Python 3.10 and later, we can make all dataclasses keyword-only.